### PR TITLE
Ensure case study assets are precached

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'devtoolbox-v2';
+const CACHE_NAME = 'devtoolbox-v3';
 const ASSETS = [
   './',
   './index.html',
@@ -6,7 +6,10 @@ const ASSETS = [
   './css/animations.css',
   './js/app.js',
   './js/router.js',
-  './js/state.js'
+  './js/state.js',
+  './js/pages/home.js',
+  './js/pages/tools-hub.js',
+  './js/pages/study.js'
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- update the service worker cache to precache the study and supporting page modules
- bump the cache version so clients receive the refreshed asset list

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691260444ff4832ebb5240c7d904720f)