### PR TITLE
Handle unhandled promise rejections without browser dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/js/utils/errors.js
+++ b/js/utils/errors.js
@@ -50,6 +50,9 @@ export function installGlobalErrorHandlers() {
     });
   });
   window.addEventListener('unhandledrejection', (event) => {
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
     handleError('global:unhandled-rejection', event.reason);
   });
   installed = true;


### PR DESCRIPTION
## Summary
- add a repository .gitignore to ignore generated Node artifacts
- prevent default browser handling when capturing unhandled promise rejections

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127304b898832e826270b74cbb893f)