### PR TITLE
Fix template literal usage across toolkit modules

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -48,7 +48,8 @@ export function initRouter(root) {
         renderPageTransition(root, `<section class="py-24 text-center">\n          <h1 class="text-3xl font-semibold">Tool not found.</h1>\n          <p class="mt-4 text-zinc-200/80">Double-check the URL or explore the tools hub.</p>\n        </section>`);
         return;
       }
-      const module = await import(`./tools/${slug}.js`);
+      const toolModulePath = `./tools/${slug}.js`;
+      const module = await import(toolModulePath);
       const view = module.default(tool);
       renderPageTransition(root, view);
       currentRoute = hash;

--- a/js/tools/jwt.js
+++ b/js/tools/jwt.js
@@ -115,6 +115,7 @@ function atobUrlSafe(value) {
     const decoder = new TextDecoder('utf-8', { fatal: true });
     return decoder.decode(bytes);
   } catch (error) {
-    throw new Error(`Invalid base64url encoding: ${error.message}`);
+    const message = `Invalid base64url encoding: ${error.message}`;
+    throw new Error(message);
   }
 }

--- a/js/tools/md.js
+++ b/js/tools/md.js
@@ -56,18 +56,22 @@ function parseMarkdown(text) {
   lines.forEach((line) => {
     if (line.startsWith('# ')) {
       flushList();
-      html.push(`<h1>${escapeHtml(line.slice(2))}</h1>`);
+      const heading = escapeHtml(line.slice(2));
+      html.push(`<h1>${heading}</h1>`);
     } else if (line.startsWith('## ')) {
       flushList();
-      html.push(`<h2>${escapeHtml(line.slice(3))}</h2>`);
+      const subheading = escapeHtml(line.slice(3));
+      html.push(`<h2>${subheading}</h2>`);
     } else if (line.startsWith('- ')) {
-      list.push(`<li>${escapeHtml(line.slice(2))}</li>`);
+      const item = escapeHtml(line.slice(2));
+      list.push(`<li>${item}</li>`);
     } else if (line.trim() === '') {
       flushList();
       html.push('<p class="h-4"></p>');
     } else {
       flushList();
-      html.push(`<p>${escapeHtml(line)}</p>`);
+      const paragraph = escapeHtml(line);
+      html.push(`<p>${paragraph}</p>`);
     }
   });
   flushList();

--- a/js/tools/schema.js
+++ b/js/tools/schema.js
@@ -76,14 +76,18 @@ async function init() {
 function validateData(schema, data, path) {
   const errors = [];
   if (schema.type) {
+    const typeError = (expected) => `${path} should be ${expected}`;
     if (schema.type === 'object') {
       if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-        errors.push(`${path} should be an object`);
+        errors.push(typeError('an object'));
         return errors;
       }
       if (schema.required) {
         schema.required.forEach((key) => {
-          if (!(key in data)) errors.push(`${path} missing required property ${key}`);
+          if (!(key in data)) {
+            const missingPropertyMessage = `${path} missing required property ${key}`;
+            errors.push(missingPropertyMessage);
+          }
         });
       }
       if (schema.properties) {
@@ -95,18 +99,18 @@ function validateData(schema, data, path) {
       }
     } else if (schema.type === 'array') {
       if (!Array.isArray(data)) {
-        errors.push(`${path} should be an array`);
+        errors.push(typeError('an array'));
       } else if (schema.items) {
         data.forEach((item, index) => {
           errors.push(...validateData(schema.items, item, `${path}/${index}`));
         });
       }
     } else if (schema.type === 'string') {
-      if (typeof data !== 'string') errors.push(`${path} should be a string`);
+      if (typeof data !== 'string') errors.push(typeError('a string'));
     } else if (schema.type === 'number') {
-      if (typeof data !== 'number') errors.push(`${path} should be a number`);
+      if (typeof data !== 'number') errors.push(typeError('a number'));
     } else if (schema.type === 'boolean') {
-      if (typeof data !== 'boolean') errors.push(`${path} should be a boolean`);
+      if (typeof data !== 'boolean') errors.push(typeError('a boolean'));
     }
   }
   return errors;

--- a/js/tools/sqlfmt.js
+++ b/js/tools/sqlfmt.js
@@ -66,7 +66,8 @@ function formatSql(sql) {
     } else if (token === 'BY') {
       current.push(token);
     } else if (token === 'AND' || token === 'OR') {
-      current.push(`\n  ${token}`);
+      const clauseToken = `\n  ${token}`;
+      current.push(clauseToken);
     } else {
       current.push(token);
     }

--- a/js/utils/dates.js
+++ b/js/utils/dates.js
@@ -86,7 +86,8 @@ export function convertToZone(date, zone = 'UTC') {
       second: '2-digit'
     }).format(safeDate);
   } catch (error) {
-    throw new Error(`Unsupported time zone: ${zone}`);
+    const message = `Unsupported time zone: ${zone}`;
+    throw new Error(message);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the router's dynamic imports use explicit template literal arguments
- refactor markdown, schema, SQL, and date utilities to build template literal strings with intermediate variables
- normalize JWT decoding errors to use explicit template literal strings

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127ce3284c832e85e5cb19b7986da3)